### PR TITLE
Clean up calculator logic and fix core input/eval edge cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,19 @@ python main.py
 4. View the calculation result
 5. Keep going or select 7 to exit
 
+## Keyboard Shortcuts (Web Calculator)
+
+- `0-9`: enter numbers
+- `+`, `-`, `*`, `/`: operators
+- `.`: decimal point
+- `Enter` or `=`: calculate result
+- `Backspace`: delete last character
+- `Escape`: clear all
+- `%`: percent
+- `P`: pi constant
+- `E`: e constant
+- `S`, `C`, `T`, `R`, `L`, `N`: sin, cos, tan, sqrt, log, ln
+
 
 ## Author
 

--- a/index.html
+++ b/index.html
@@ -11,17 +11,17 @@
     <input id="display" class="display" type="text" readonly value="0" />
 
     <div class="buttons">
-      <button class="btn top-fn" data-value="Math.sin(">sin</button>
-      <button class="btn top-fn" data-value="Math.cos(">cos</button>
-      <button class="btn top-fn" data-value="Math.tan(">tan</button>
-      <button class="btn top-fn" data-value="Math.sqrt(">√</button>
-      <button class="btn top-fn" data-value="**2">x²</button>
-      <button class="btn top-fn" data-value="Math.PI">π</button>
+      <button class="btn top-fn" data-action="sin">sin</button>
+      <button class="btn top-fn" data-action="cos">cos</button>
+      <button class="btn top-fn" data-action="tan">tan</button>
+      <button class="btn top-fn" data-action="sqrt">√</button>
+      <button class="btn top-fn" data-action="square">x²</button>
+      <button class="btn top-fn" data-action="const-pi">π</button>
 
-      <button class="btn top-fn" data-value="Math.log10(">log</button>
-      <button class="btn top-fn" data-value="Math.log(">ln</button>
-      <button class="btn top-fn" data-value="Math.E">e</button>
-      <button class="btn top-fn" data-value="%">%</button>
+      <button class="btn top-fn" data-action="log">log</button>
+      <button class="btn top-fn" data-action="ln">ln</button>
+      <button class="btn top-fn" data-action="const-e">e</button>
+      <button class="btn top-fn" data-action="percent">%</button>
       <button class="btn top-fn wide-top" data-action="toggle-sign">+/-</button>
 
       <button class="btn num" data-value="7">7</button>
@@ -43,6 +43,7 @@
       <button class="btn num" data-value=".">.</button>
       <button class="btn op" data-value="+">+</button>
 
+      <button class="btn delete" data-action="delete">DEL</button>
       <button class="btn clear" data-action="clear">C</button>
       <button class="btn equal" data-action="equals">=</button>
     </div>

--- a/script.js
+++ b/script.js
@@ -1,59 +1,475 @@
 const display = document.getElementById("display");
 const buttons = document.querySelector(".buttons");
 
-let expression = "";
+const OPERATORS = new Set(["+", "-", "*", "/"]);
+const CONSTANTS = {
+  "const-pi": String(Math.PI),
+  "const-e": String(Math.E),
+};
 
-function refreshDisplay() {
-  display.value = expression || "0";
+let expression = "";
+let justEvaluated = false;
+let errorState = false;
+let lastOperator = null;
+let lastOperand = null;
+
+function isOperator(char) {
+  return OPERATORS.has(char);
+}
+
+function updateDisplay() {
+  display.value = errorState ? "Error" : expression || "0";
+}
+
+function clearAll() {
+  expression = "";
+  justEvaluated = false;
+  errorState = false;
+  lastOperator = null;
+  lastOperand = null;
+  updateDisplay();
+}
+
+function setError() {
+  errorState = true;
+  expression = "";
+  justEvaluated = false;
+  lastOperator = null;
+  lastOperand = null;
+  updateDisplay();
+}
+
+function clearErrorIfNeeded() {
+  if (errorState) {
+    errorState = false;
+    expression = "";
+  }
+}
+
+function formatNumber(value) {
+  const rounded = Math.round((value + Number.EPSILON) * 1e12) / 1e12;
+  return String(rounded);
+}
+
+function stripTrailingInvalid(value) {
+  let cleaned = value.trim();
+  while (cleaned && (isOperator(cleaned.at(-1)) || cleaned.at(-1) === ".")) {
+    cleaned = cleaned.slice(0, -1);
+  }
+  return cleaned;
+}
+
+function getLastNumberStart(value) {
+  let index = value.length - 1;
+
+  while (index >= 0 && /[0-9.]/.test(value[index])) {
+    index -= 1;
+  }
+
+  if (
+    index >= 0 &&
+    value[index] === "-" &&
+    (index === 0 || isOperator(value[index - 1]))
+  ) {
+    index -= 1;
+  }
+
+  return index + 1;
+}
+
+function evaluateExpression(rawExpression = expression) {
+  const cleaned = stripTrailingInvalid(rawExpression);
+  if (!cleaned || cleaned === "-") return null;
+
+  if (!/^[0-9+\-*/().\s]+$/.test(cleaned)) {
+    throw new Error("Invalid characters in expression.");
+  }
+
+  const result = Function(`"use strict"; return (${cleaned});`)();
+  if (!Number.isFinite(result)) {
+    throw new Error("Expression did not produce a finite number.");
+  }
+
+  return result;
+}
+
+function extractLastBinaryOperation(value) {
+  const cleaned = stripTrailingInvalid(value);
+  const operandMatch = cleaned.match(/(-?\d*\.?\d+)$/);
+  if (!operandMatch) return null;
+
+  const operand = operandMatch[1];
+  const operandStart = operandMatch.index;
+  const operatorIndex = operandStart - 1;
+  if (operatorIndex < 0) return null;
+
+  const operator = cleaned[operatorIndex];
+  if (!isOperator(operator)) return null;
+  if (operator === "-" && (operatorIndex === 0 || isOperator(cleaned[operatorIndex - 1]))) {
+    return null;
+  }
+
+  return { operator, operand };
+}
+
+function appendDigit(digit) {
+  clearErrorIfNeeded();
+
+  if (justEvaluated) {
+    expression = "";
+    justEvaluated = false;
+  }
+
+  const numberStart = getLastNumberStart(expression);
+  const currentNumber = expression.slice(numberStart);
+
+  if (currentNumber === "0") {
+    if (digit === "0") return;
+    expression = expression.slice(0, numberStart) + digit;
+    updateDisplay();
+    return;
+  }
+
+  if (currentNumber === "-0") {
+    if (digit === "0") return;
+    expression = expression.slice(0, numberStart) + `-${digit}`;
+    updateDisplay();
+    return;
+  }
+
+  expression += digit;
+  updateDisplay();
+}
+
+function appendDecimal() {
+  clearErrorIfNeeded();
+
+  if (justEvaluated) {
+    expression = "";
+    justEvaluated = false;
+  }
+
+  const numberStart = getLastNumberStart(expression);
+  const currentNumber = expression.slice(numberStart);
+  if (currentNumber.includes(".")) return;
+
+  if (currentNumber === "" || currentNumber === "-") {
+    expression += "0.";
+  } else {
+    expression += ".";
+  }
+
+  updateDisplay();
+}
+
+function appendOperator(operator) {
+  clearErrorIfNeeded();
+
+  if (!expression) {
+    if (operator === "-") {
+      expression = "-";
+      updateDisplay();
+    }
+    return;
+  }
+
+  if (justEvaluated) {
+    justEvaluated = false;
+  }
+
+  if (expression.endsWith(".")) {
+    expression += "0";
+  }
+
+  const trailingOperators = expression.match(/[+\-*/]+$/)?.[0];
+  if (trailingOperators) {
+    // Allow patterns like "5*-" so the next number can be negative.
+    if (operator === "-" && trailingOperators.length === 1 && trailingOperators !== "-") {
+      expression += "-";
+    } else {
+      const withoutTrailing = expression.slice(0, -trailingOperators.length);
+      expression = withoutTrailing ? withoutTrailing + operator : operator === "-" ? "-" : "";
+    }
+    updateDisplay();
+    return;
+  }
+
+  expression += operator;
+  updateDisplay();
+}
+
+function deleteLast() {
+  if (errorState) {
+    clearAll();
+    return;
+  }
+
+  justEvaluated = false;
+  expression = expression.slice(0, -1);
+  updateDisplay();
+}
+
+function toggleSign() {
+  clearErrorIfNeeded();
+
+  if (!expression) {
+    expression = "-";
+    updateDisplay();
+    return;
+  }
+
+  if (justEvaluated) {
+    expression = expression.startsWith("-") ? expression.slice(1) : `-${expression}`;
+    justEvaluated = false;
+    updateDisplay();
+    return;
+  }
+
+  const numberStart = getLastNumberStart(expression);
+  const currentNumber = expression.slice(numberStart);
+
+  if (!currentNumber) {
+    if (isOperator(expression.at(-1))) {
+      expression += "-";
+    } else {
+      expression = expression.startsWith("-") ? expression.slice(1) : `-${expression}`;
+    }
+    updateDisplay();
+    return;
+  }
+
+  if (currentNumber === "-") {
+    expression = expression.slice(0, numberStart);
+  } else if (currentNumber.startsWith("-")) {
+    expression = expression.slice(0, numberStart) + currentNumber.slice(1);
+  } else {
+    expression = expression.slice(0, numberStart) + `-${currentNumber}`;
+  }
+
+  updateDisplay();
+}
+
+function appendConstant(action) {
+  clearErrorIfNeeded();
+
+  if (justEvaluated) {
+    expression = "";
+    justEvaluated = false;
+  }
+
+  const constantValue = CONSTANTS[action];
+  const previous = expression.at(-1);
+  const shouldMultiply = previous && /[0-9.]/.test(previous);
+
+  expression += shouldMultiply ? `*${constantValue}` : constantValue;
+  updateDisplay();
+}
+
+function applyUnaryOperation(action) {
+  clearErrorIfNeeded();
+
+  try {
+    const value = evaluateExpression();
+    if (value === null) return;
+
+    let result;
+    switch (action) {
+      case "sin":
+        result = Math.sin(value);
+        break;
+      case "cos":
+        result = Math.cos(value);
+        break;
+      case "tan":
+        result = Math.tan(value);
+        break;
+      case "sqrt":
+        if (value < 0) throw new Error("Square root domain error.");
+        result = Math.sqrt(value);
+        break;
+      case "square":
+        result = value ** 2;
+        break;
+      case "log":
+        if (value <= 0) throw new Error("Log domain error.");
+        result = Math.log10(value);
+        break;
+      case "ln":
+        if (value <= 0) throw new Error("Natural log domain error.");
+        result = Math.log(value);
+        break;
+      case "percent":
+        result = value / 100;
+        break;
+      default:
+        return;
+    }
+
+    expression = formatNumber(result);
+    justEvaluated = true;
+    lastOperator = null;
+    lastOperand = null;
+    updateDisplay();
+  } catch (error) {
+    setError();
+  }
+}
+
+function handleEquals() {
+  if (errorState) return;
+
+  try {
+    if (justEvaluated && lastOperator && lastOperand !== null) {
+      const repeatedResult = evaluateExpression(`${expression}${lastOperator}${lastOperand}`);
+      if (repeatedResult === null) return;
+      expression = formatNumber(repeatedResult);
+      updateDisplay();
+      return;
+    }
+
+    const cleaned = stripTrailingInvalid(expression);
+    if (!cleaned || cleaned === "-") return;
+
+    const operation = extractLastBinaryOperation(cleaned);
+    const result = evaluateExpression(cleaned);
+    if (result === null) return;
+
+    expression = formatNumber(result);
+    justEvaluated = true;
+    lastOperator = operation?.operator ?? null;
+    lastOperand = operation?.operand ?? null;
+    updateDisplay();
+  } catch (error) {
+    setError();
+  }
+}
+
+function handleButtonPress(button) {
+  const value = button.dataset.value;
+  const action = button.dataset.action;
+
+  if (value !== undefined) {
+    if (/[0-9]/.test(value)) {
+      appendDigit(value);
+      return;
+    }
+    if (value === ".") {
+      appendDecimal();
+      return;
+    }
+    if (isOperator(value)) {
+      appendOperator(value);
+    }
+    return;
+  }
+
+  if (action === "clear") {
+    clearAll();
+    return;
+  }
+
+  if (action === "delete") {
+    deleteLast();
+    return;
+  }
+
+  if (action === "toggle-sign") {
+    toggleSign();
+    return;
+  }
+
+  if (action === "equals") {
+    handleEquals();
+    return;
+  }
+
+  if (action in CONSTANTS) {
+    appendConstant(action);
+    return;
+  }
+
+  applyUnaryOperation(action);
+}
+
+function handleKeyboardInput(event) {
+  const { key } = event;
+  const lowerKey = key.toLowerCase();
+
+  if (/^[0-9]$/.test(key)) {
+    event.preventDefault();
+    appendDigit(key);
+    return;
+  }
+
+  if (key === ".") {
+    event.preventDefault();
+    appendDecimal();
+    return;
+  }
+
+  if (isOperator(key)) {
+    event.preventDefault();
+    appendOperator(key);
+    return;
+  }
+
+  if (key === "=" || key === "Enter") {
+    event.preventDefault();
+    handleEquals();
+    return;
+  }
+
+  if (key === "Backspace") {
+    event.preventDefault();
+    deleteLast();
+    return;
+  }
+
+  if (key === "Escape") {
+    event.preventDefault();
+    clearAll();
+    return;
+  }
+
+  if (key === "%") {
+    event.preventDefault();
+    applyUnaryOperation("percent");
+    return;
+  }
+
+  if (lowerKey === "p") {
+    event.preventDefault();
+    appendConstant("const-pi");
+    return;
+  }
+
+  if (lowerKey === "e") {
+    event.preventDefault();
+    appendConstant("const-e");
+    return;
+  }
+
+  const scientificShortcuts = {
+    s: "sin",
+    c: "cos",
+    t: "tan",
+    r: "sqrt",
+    l: "log",
+    n: "ln",
+  };
+
+  if (scientificShortcuts[lowerKey]) {
+    event.preventDefault();
+    applyUnaryOperation(scientificShortcuts[lowerKey]);
+  }
 }
 
 buttons.addEventListener("click", (event) => {
   const button = event.target.closest("button");
   if (!button) return;
-
-  const value = button.dataset.value;
-  const action = button.dataset.action;
-
-  if (value !== undefined) {
-    if (value === "**2") {
-      expression += "**2";
-    } else {
-      expression += value;
-    }
-    refreshDisplay();
-    return;
-  }
-
-  if (action === "clear") {
-    expression = "";
-    refreshDisplay();
-    return;
-  }
-
-  if (action === "toggle-sign") {
-    if (!expression) return;
-
-    if (expression.startsWith("-")) {
-      expression = expression.slice(1);
-    } else {
-      expression = "-" + expression;
-    }
-    refreshDisplay();
-    return;
-  }
-
-  if (action === "equals") {
-    if (!expression.trim()) return;
-
-    try {
-      const result = eval(expression);
-      expression = String(result);
-      refreshDisplay();
-    } catch (error) {
-      expression = "";
-      display.value = "Error";
-    }
-  }
+  handleButtonPress(button);
 });
 
-refreshDisplay();
+document.addEventListener("keydown", handleKeyboardInput);
+
+updateDisplay();

--- a/style.css
+++ b/style.css
@@ -126,11 +126,19 @@ body {
   font-size: 24px;
 }
 
+.delete {
+  background: var(--clear-btn);
+  border-color: var(--clear-btn-border);
+  color: var(--white-text);
+  min-height: 72px;
+  font-size: 20px;
+}
+
 .equal {
   background: var(--equal-btn);
   border-color: var(--equal-btn-border);
   color: var(--white-text);
-  grid-column: span 3;
+  grid-column: span 2;
   min-height: 72px;
   font-size: 24px;
 }
@@ -162,6 +170,7 @@ body {
   }
 
   .op,
+  .delete,
   .clear,
   .equal,
   .num {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- replaced fragile string-appending scientific actions with explicit button actions
- refactored calculator state handling in `script.js` for clearer, predictable behavior
- added robust handling for decimals, operator chaining, repeated equals, sign toggling, clear/delete, and error recovery
- preserved existing visual design with only a minimal layout adjustment to add a `DEL` button
- added keyboard support for common calculator flows (digits/operators/enter/backspace/escape plus scientific shortcuts)
- added a concise `README.md` keyboard shortcut note for the web calculator

## What was fixed
- scientific buttons (`sin`, `cos`, `tan`, `sqrt`, `log`, `ln`) no longer insert invalid `Math.*(` fragments
- decimal input now blocks duplicate decimal points per number and supports leading decimal input (`0.`)
- operator chaining now replaces invalid trailing operators and supports `* -` style negative operand entry
- equals now supports repeated presses (re-applies last binary operation)
- division by zero and invalid expressions now show `Error` and recover cleanly on next input
- added delete behavior (`DEL`) to remove one character at a time
- after showing a result, entering a number starts a new expression while entering an operator continues the result

## Testing
- executed a local simulated interaction harness in Node to cover:
  - all button categories
  - long/chained expressions
  - repeated operators
  - decimal edge cases
  - negative numbers
  - scientific operations and constants
  - clear/delete flows
  - repeated equals behavior
  - error state and recovery
  - keyboard input paths
- performed a mobile viewport visual check at `390x844` and confirmed spacing/readability is good (no overlap, buttons remain tappable, labels legible)

All simulated checks passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47bdc38c-533f-4df9-9bde-8920b83ccd30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47bdc38c-533f-4df9-9bde-8920b83ccd30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

